### PR TITLE
Stop throwing exceptions for unmapped fields

### DIFF
--- a/src/main/kotlin/org/treeWare/proto3/message/ComputeSerializedSize.kt
+++ b/src/main/kotlin/org/treeWare/proto3/message/ComputeSerializedSize.kt
@@ -52,7 +52,7 @@ private class ComputeSerializedSizeVisitor :
         // Entities are represented as messages, and they are not packed, so include tag size.
         val parentFieldMeta = leaderEntity1.parent.meta
         val fieldNumber = getProto3MetaModelMap(parentFieldMeta)?.validated?.fieldNumber
-            ?: throw IllegalStateException()
+            ?: return TraversalAction.CONTINUE
         val tagSize = CodedOutputStream.computeTagSize(fieldNumber)
         return visitElement(tagSize)
     }
@@ -139,7 +139,7 @@ private class ComputeSerializedSizeVisitor :
                 if (string.isEmpty()) 0 else {
                     // Non-packable type, so include tag size.
                     val fieldNumber = getProto3MetaModelMap(parentMeta)?.validated?.fieldNumber
-                        ?: throw IllegalStateException()
+                        ?: return TraversalAction.CONTINUE
                     val tagSize = CodedOutputStream.computeTagSize(fieldNumber)
                     tagSize + CodedOutputStream.computeStringSizeNoTag(string)
                 }
@@ -149,7 +149,7 @@ private class ComputeSerializedSizeVisitor :
                 if (bytes.isEmpty()) 0 else {
                     // Non-packable type, so include tag size.
                     val fieldNumber = getProto3MetaModelMap(parentMeta)?.validated?.fieldNumber
-                        ?: throw IllegalStateException()
+                        ?: return TraversalAction.CONTINUE
                     val tagSize = CodedOutputStream.computeTagSize(fieldNumber)
                     tagSize + CodedOutputStream.computeByteArraySizeNoTag(bytes)
                 }

--- a/src/main/kotlin/org/treeWare/proto3/message/Serialize.kt
+++ b/src/main/kotlin/org/treeWare/proto3/message/Serialize.kt
@@ -35,7 +35,7 @@ private class SerializeVisitor(
         // NOTE: even if a message is empty, its tag and length (0) need to be included.
         val parentFieldMeta = leaderEntity1.parent.meta
         val fieldNumber = getProto3MetaModelMap(parentFieldMeta)?.validated?.fieldNumber
-            ?: throw IllegalStateException()
+            ?: return TraversalAction.CONTINUE
         writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED)
         writeLength(length)
         return TraversalAction.CONTINUE
@@ -54,7 +54,7 @@ private class SerializeVisitor(
         if (length <= 0) return TraversalAction.CONTINUE
         if (isPackedType(leaderField1)) {
             val fieldNumber = getProto3MetaModelMap(leaderField1.meta)?.validated?.fieldNumber
-                ?: throw IllegalStateException()
+                ?: return TraversalAction.CONTINUE
             val wireType = getWireType(leaderField1)
             writeTag(fieldNumber, wireType)
         }
@@ -66,7 +66,7 @@ private class SerializeVisitor(
         if (length <= 0) return TraversalAction.CONTINUE
         if (isPackedType(leaderField1)) {
             val fieldNumber = getProto3MetaModelMap(leaderField1.meta)?.validated?.fieldNumber
-                ?: throw IllegalStateException()
+                ?: return TraversalAction.CONTINUE
             writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED)
             writeLength(length)
         }
@@ -120,7 +120,7 @@ private class SerializeVisitor(
                 if (string.isNotEmpty()) {
                     // Non-packable type, so include tag.
                     val fieldNumber = getProto3MetaModelMap(parentMeta)?.validated?.fieldNumber
-                        ?: throw IllegalStateException()
+                        ?: return TraversalAction.CONTINUE
                     output.writeString(fieldNumber, string)
                 }
             }
@@ -129,7 +129,7 @@ private class SerializeVisitor(
                 if (bytes.isNotEmpty()) {
                     // Non-packable type, so include tag.
                     val fieldNumber = getProto3MetaModelMap(parentMeta)?.validated?.fieldNumber
-                        ?: throw IllegalStateException()
+                        ?: return TraversalAction.CONTINUE
                     output.writeByteArray(fieldNumber, bytes)
                 }
             }


### PR DESCRIPTION
Not all meta-model fields will be mapped to proto fields. Such fields
should be skipped instead of throwing exceptions.